### PR TITLE
feat: support 2020-12 defs and refs

### DIFF
--- a/src/diff_walker.rs
+++ b/src/diff_walker.rs
@@ -350,12 +350,11 @@ impl<F: FnMut(Change)> DiffWalker<F> {
     }
 
     fn resolve_ref<'a>(root_schema: &'a RootSchema, reference: &str) -> Option<&'a Schema> {
-        if let Some(definition_name) = reference.strip_prefix("#/definitions/") {
-            let schema_object = root_schema.definitions.get(definition_name)?;
-            Some(schema_object)
-        } else {
-            None
-        }
+        let definition_name = reference
+            .strip_prefix("#/definitions/")
+            .or(reference.strip_prefix("#/$defs/"))
+            .unwrap_or(reference);
+        root_schema.definitions.get(definition_name)
     }
 
     fn resolve_references(

--- a/tests/fixtures/ref/factor_out_definitions_using_defs_keyword.json
+++ b/tests/fixtures/ref/factor_out_definitions_using_defs_keyword.json
@@ -1,0 +1,11 @@
+{
+  "lhs": {
+    "type": "object"
+  },
+  "rhs": {
+    "$ref": "#/$defs/Hello",
+    "$defs": {
+      "Hello": {"type": "object"}
+    }
+  }
+}

--- a/tests/fixtures/ref/factor_out_definitions_using_defs_keyword_and_change.json
+++ b/tests/fixtures/ref/factor_out_definitions_using_defs_keyword_and_change.json
@@ -1,0 +1,11 @@
+{
+  "lhs": {
+    "type": "object"
+  },
+  "rhs": {
+    "$ref": "#/$defs/Hello",
+    "$defs": {
+      "Hello": {"type": "array"}
+    }
+  }
+}

--- a/tests/fixtures/ref/factor_out_definitions_using_uri_reference.json
+++ b/tests/fixtures/ref/factor_out_definitions_using_uri_reference.json
@@ -1,0 +1,11 @@
+{
+  "lhs": {
+    "type": "object"
+  },
+  "rhs": {
+    "$ref": "Hello",
+    "$defs": {
+      "Hello": {"type": "object"}
+    }
+  }
+}

--- a/tests/fixtures/ref/factor_out_definitions_using_uri_reference_and_change.json
+++ b/tests/fixtures/ref/factor_out_definitions_using_uri_reference_and_change.json
@@ -1,0 +1,11 @@
+{
+  "lhs": {
+    "type": "object"
+  },
+  "rhs": {
+    "$ref": "Hello",
+    "$defs": {
+      "Hello": {"type": "array"}
+    }
+  }
+}

--- a/tests/snapshots/test__from_fixtures@ref__factor_out_definitions_using_defs_keyword.json.snap
+++ b/tests/snapshots/test__from_fixtures@ref__factor_out_definitions_using_defs_keyword.json.snap
@@ -1,0 +1,14 @@
+---
+source: tests/test.rs
+expression: diff
+info:
+  lhs:
+    type: object
+  rhs:
+    $defs:
+      Hello:
+        type: object
+    $ref: "#/$defs/Hello"
+input_file: tests/fixtures/ref/factor_out_definitions_using_defs_keyword.json
+---
+[]

--- a/tests/snapshots/test__from_fixtures@ref__factor_out_definitions_using_defs_keyword_and_change.json.snap
+++ b/tests/snapshots/test__from_fixtures@ref__factor_out_definitions_using_defs_keyword_and_change.json.snap
@@ -1,0 +1,27 @@
+---
+source: tests/test.rs
+expression: diff
+info:
+  lhs:
+    type: object
+  rhs:
+    $defs:
+      Hello:
+        type: array
+    $ref: "#/$defs/Hello"
+input_file: tests/fixtures/ref/factor_out_definitions_using_defs_keyword_and_change.json
+---
+[
+    Change {
+        path: "",
+        change: TypeRemove {
+            removed: Object,
+        },
+    },
+    Change {
+        path: "",
+        change: TypeAdd {
+            added: Array,
+        },
+    },
+]

--- a/tests/snapshots/test__from_fixtures@ref__factor_out_definitions_using_uri_reference.json.snap
+++ b/tests/snapshots/test__from_fixtures@ref__factor_out_definitions_using_uri_reference.json.snap
@@ -1,0 +1,14 @@
+---
+source: tests/test.rs
+expression: diff
+info:
+  lhs:
+    type: object
+  rhs:
+    $defs:
+      Hello:
+        type: object
+    $ref: Hello
+input_file: tests/fixtures/ref/factor_out_definitions_using_uri_reference.json
+---
+[]

--- a/tests/snapshots/test__from_fixtures@ref__factor_out_definitions_using_uri_reference_and_change.json.snap
+++ b/tests/snapshots/test__from_fixtures@ref__factor_out_definitions_using_uri_reference_and_change.json.snap
@@ -1,0 +1,27 @@
+---
+source: tests/test.rs
+expression: diff
+info:
+  lhs:
+    type: object
+  rhs:
+    $defs:
+      Hello:
+        type: array
+    $ref: Hello
+input_file: tests/fixtures/ref/factor_out_definitions_using_uri_reference_and_change.json
+---
+[
+    Change {
+        path: "",
+        change: TypeRemove {
+            removed: Object,
+        },
+    },
+    Change {
+        path: "",
+        change: TypeAdd {
+            added: Array,
+        },
+    },
+]


### PR DESCRIPTION
json-schema draft [2019-09](https://json-schema.org/draft/2019-09) and [2020-12](https://json-schema.org/draft/2020-12)  deprecate storing definitions under the `definitions` property and instead create a special `$defs` property which works the same.

Most examples we found use the `#/$defs/some-name` $ref syntax, but a URI-Reference is also supported.

CX-1150
